### PR TITLE
Added optional method.

### DIFF
--- a/Classes/CalendarView.h
+++ b/Classes/CalendarView.h
@@ -67,6 +67,8 @@
 -(void)dayChangedToDate:(NSDate *)selectedDate;
 
 @optional
+-(BOOL)shouldChangeDayToDate:(NSDate *)selectedDate;
+
 -(void)setHeightNeeded:(NSInteger)heightNeeded;
 -(void)setMonthLabel:(NSString *)monthLabel;
 -(void)setEnabledForPrevMonthButton:(BOOL)enablePrev nextMonthButton:(BOOL)enableNext;

--- a/Classes/CalendarView.m
+++ b/Classes/CalendarView.m
@@ -217,6 +217,13 @@
     return [_datasource canSwipeToDate:date];
 }
 
+-(BOOL)shouldChangeDayToDate:(NSDate *)date {
+    if ([_delegate respondsToSelector:@selector(shouldChangeDayToDate:)]) {
+        return [_delegate shouldChangeDayToDate:date];
+    }
+    return YES;
+}
+
 -(void)performViewAnimation:(UIViewAnimationOptions)animation
 {
     NSDateComponents * components = [_gregorian components:_dayInfoUnits fromDate:_selectedDate];
@@ -323,7 +330,7 @@
         components.month += offsetMonth;
         NSDate * otherMonthDate =[_gregorian dateFromComponents:components];
         
-        if ([self canSwipeToDate:otherMonthDate])
+        if ([self canSwipeToDate:otherMonthDate] || [self shouldChangeDayToDate:otherMonthDate])
         {
             [self.subviews makeObjectsPerformSelector:@selector(removeFromSuperview)];
             _calendarDate = otherMonthDate;
@@ -356,6 +363,12 @@
         componentsDateSel.month     = components.month;
         componentsDateSel.year      = components.year;
         _selectedDate               = [_gregorian dateFromComponents:componentsDateSel];
+        
+        // If returns NO, restore the old date and return
+        if (![self shouldChangeDayToDate:_selectedDate]) {
+            _selectedDate = oldSelectedDate;
+            return;
+        }
         
         // Configure  the new selected day button
         [self configureDayButton:sender             withDate:_selectedDate];

--- a/sampleCalendar/DefaultCalendarViewController.m
+++ b/sampleCalendar/DefaultCalendarViewController.m
@@ -48,6 +48,13 @@
     NSLog(@"dayChangedToDate %@(GMT)",selectedDate);
 }
 
+-(BOOL)shouldChangeDayToDate:(NSDate *)selectedDate
+{
+    if ([[NSDate date] compare:selectedDate] == NSOrderedAscending) {
+        return YES;
+    }
+    return NO;
+}
 #pragma mark - Action methods
 
 - (void)didReceiveMemoryWarning


### PR DESCRIPTION
Added optional method 'shouldChangeDayToDate:' in CalendarDelegate protocol to allow selection on per day basis. 

In some cases being informed about the selection of a day is not sufficient. You need control over which day should be selected and which should not. This delegate method allows the user to cherry pick the selected day.
